### PR TITLE
fix: install tailwindcss v4 package and regenerate lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "recharts": "2.15.0",
         "sonner": "^1.7.1",
         "tailwind-merge": "^2.5.5",
+        "tailwindcss": "^4.0.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2",
         "zod": "^3.24.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,9 +152,12 @@ importers:
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.0
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.1.11
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7
+        version: 1.0.7(tailwindcss@4.1.11)
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3628,7 +3631,9 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7: {}
+  tailwindcss-animate@1.0.7(tailwindcss@4.1.11):
+    dependencies:
+      tailwindcss: 4.1.11
 
   tailwindcss@4.1.11: {}
 


### PR DESCRIPTION
- Add tailwindcss@4.1.11 to dependencies for @import directive support
- Regenerate pnpm-lock.yaml with proper dependency resolution
- Fixes 'Can't resolve tailwindcss' build error during deployment
- Build tested and working correctly