### PR TITLE
fix: Handle OAuth redirects that land on root URL

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,26 @@
 "use client"
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
+import { useEffect, Suspense } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useAuth } from "@/components/auth-provider"
 import LandingPage from "@/components/landing-page"
 
-export default function Home() {
+function HomeContent() {
   const { user, loading } = useAuth()
   const router = useRouter()
+  const searchParams = useSearchParams()
+
+  // Handle OAuth callback if code is present in URL
+  useEffect(() => {
+    const code = searchParams.get("code")
+    if (code) {
+      // Redirect to the callback route with the code
+      const currentUrl = new URL(window.location.href)
+      currentUrl.pathname = "/auth/callback"
+      router.replace(currentUrl.toString())
+      return
+    }
+  }, [searchParams, router])
 
   useEffect(() => {
     if (!loading && user) {
@@ -31,4 +44,21 @@ export default function Home() {
   }
 
   return <LandingPage />
+}
+
+export default function Home() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+            <p className="text-muted-foreground">Loading...</p>
+          </div>
+        </div>
+      }
+    >
+      <HomeContent />
+    </Suspense>
+  )
 }

--- a/components/auth-provider.tsx
+++ b/components/auth-provider.tsx
@@ -105,13 +105,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             // Get the current origin to ensure correct redirect URL
             // Use window.location.origin which automatically detects the correct URL
             // (localhost:3000 in development, production URL in production)
-            const origin = window.location.origin;
+            // If NEXT_PUBLIC_SITE_URL is set, use it for production consistency
+            const origin = 
+                process.env.NEXT_PUBLIC_SITE_URL || 
+                window.location.origin;
             const redirectUrl = `${origin}/auth/callback`;
             
-            // Log for debugging (remove in production if needed)
-            if (process.env.NODE_ENV === "development") {
-                console.log("OAuth redirect URL:", redirectUrl);
-            }
+            // Log for debugging
+            console.log("OAuth redirect URL:", redirectUrl);
             
             const { error } = await supabase.auth.signInWithOAuth({
                 provider: "google",


### PR DESCRIPTION
- Added OAuth callback handler in root page to redirect /?code=... to /auth/callback
- Improved OAuth sign-in to use NEXT_PUBLIC_SITE_URL environment variable when available
- Added Suspense wrapper for useSearchParams in root page
- Fixes issue where Supabase redirects to root URL instead of /auth/callback
- Works in both local and production environments